### PR TITLE
Support PR summary

### DIFF
--- a/assets/svelte/CodeDiff.svelte
+++ b/assets/svelte/CodeDiff.svelte
@@ -17,6 +17,27 @@
     diff2htmlUi.draw();
     diff2htmlUi.highlightCode();
   }
+
+  const handleMouseUp = (_e: MouseEvent) => {
+    const selection = document.getSelection();
+
+    const getLineNumber = (n: Node) => {
+      try {
+        const tr = n.parentElement.closest("tr");
+        const [td, _] = tr.querySelectorAll("td");
+        const left = td.querySelector("div.line-num1").textContent;
+        const right = td.querySelector("div.line-num2").textContent;
+        return [left, right];
+      } catch (_) {
+        return null;
+      }
+    };
+
+    const _ = [
+      getLineNumber(selection.anchorNode),
+      getLineNumber(selection.focusNode),
+    ];
+  };
 </script>
 
 <svelte:head>
@@ -39,4 +60,5 @@
   </style>
 </svelte:head>
 
-<div bind:this={element} />
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div bind:this={element} on:mouseup={handleMouseUp} />

--- a/config/config.exs
+++ b/config/config.exs
@@ -74,7 +74,8 @@ config :ueberauth, Ueberauth,
 
 config :fastrepl, Oban,
   engine: Oban.Engines.Basic,
-  queues: [default: 10],
+  plugins: [{Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 2}],
+  queues: [default: 50, pr: 20],
   repo: Fastrepl.Repo
 
 config :fastrepl, :env, Mix.env()

--- a/lib/fastrepl/github/github.ex
+++ b/lib/fastrepl/github/github.ex
@@ -52,14 +52,22 @@ defmodule Fastrepl.Github do
     |> Enum.flat_map(& &1.repo_full_names)
   end
 
-  def get_installation_token!(installation_id) do
-    {:ok, %{token: token}} =
+  def get_installation_token(installation_id) do
+    result =
       GitHub.Apps.create_installation_access_token(
         installation_id,
         %{},
         auth: GitHub.app(:fastrepl)
       )
 
+    case result do
+      {:ok, %{token: token}} -> {:ok, token}
+      others -> {:error, others}
+    end
+  end
+
+  def get_installation_token!(installation_id) do
+    {:ok, token} = get_installation_token(installation_id)
     token
   end
 

--- a/lib/fastrepl/pr/summary.ex
+++ b/lib/fastrepl/pr/summary.ex
@@ -111,6 +111,9 @@ defmodule Fastrepl.PullRequest.Summary do
             Ideally, there should be no `#### Minor Changes` section. But sometimes, PR contains some changes that are not related to the main purpose of the PR.
             If that change is not small enough to ignore, place it at `#### Major Changes` section.
 
+            For both `#### Major Changes` and `#### Minor Changes`, try to merge multiple commits into one change if they are related.
+            For example, if one commit create module calling OpenAI, and other commit change model name gpt-3.5-turbo to gpt-4, it should be merged into one change.
+
             At the high level, it should look like this:
 
             ### Description
@@ -173,6 +176,17 @@ defmodule Fastrepl.PullRequest.Summary do
 
           Keep in mind that although it is best practice to have single main change in a PR, often it contains lots of small, unrelated changes.'
           Your job is to identify only the core changes, and restate it in a concise sentences. With your input, I will later summarize the changes in the PR while classifying them into `Major Changes` and `Minor Changes`.
+
+          For example, your response should look like this:
+
+          Core changes are:
+          - Updated config.ex for Oban
+          - Added Oban worker in Fastrepl.PullRequest.Summary
+          - Updated github webhook handler for pull_request event
+
+          Unrelated changes are:
+          - Added fallback in webhook handler
+          - Updated CodeDiff.svelte
           """
         },
         %{

--- a/lib/fastrepl/pr/summary.ex
+++ b/lib/fastrepl/pr/summary.ex
@@ -1,0 +1,194 @@
+defmodule Fastrepl.PullRequest.Summary do
+  use Oban.Worker,
+    queue: :pr,
+    unique: [
+      fields: [:args],
+      keys: [:github_repo_full_name, :github_issue_number],
+      states: [
+        :available,
+        :scheduled,
+        :retryable
+      ],
+      period: :infinity
+    ],
+    replace: [
+      available: [:args, :scheduled_at],
+      scheduled: [:args, :scheduled_at],
+      retryable: [:args, :scheduled_at]
+    ]
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    impl(args)
+  end
+
+  @summary_regex ~r/<details by="fastrepl">.*?<\/details>/s
+
+  defp impl(%{
+         "github_repo_full_name" => github_repo_full_name,
+         "github_issue_number" => github_issue_number,
+         "installation_id" => installation_id
+       }) do
+    [owner, repo] = String.split(github_repo_full_name, "/")
+
+    with {:ok, token} <- Fastrepl.Github.get_installation_token(installation_id),
+         {:ok, pr} <- get_pr(owner, repo, github_issue_number, token),
+         {:ok, commits} <- get_commits(owner, repo, github_issue_number, token),
+         {:ok, comment} <- write_comment(pr, commits) do
+      updated_pr_body =
+        case Regex.run(@summary_regex, pr.body) do
+          nil -> pr.body <> "\n\n" <> comment
+          [_] -> Regex.replace(@summary_regex, pr.body, comment)
+        end
+
+      GitHub.Pulls.update(
+        owner,
+        repo,
+        github_issue_number,
+        %{body: updated_pr_body},
+        auth: token
+      )
+    end
+  end
+
+  defp get_pr(owner, repo, issue_number, token) do
+    case GitHub.Pulls.get(owner, repo, issue_number, auth: token) do
+      {:ok, pr} ->
+        {:ok, %{title: pr.title, body: Regex.replace(@summary_regex, pr.body || "", "")}}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp get_commits(owner, repo, issue_number, token) do
+    case GitHub.Pulls.list_commits(owner, repo, issue_number, auth: token) do
+      {:ok, commits} ->
+        commits =
+          commits
+          |> Enum.map(fn %{sha: sha} -> sha end)
+          |> Enum.map(fn sha ->
+            case GitHub.Repos.get_commit(owner, repo, sha, auth: token) do
+              {:ok, %{commit: %{message: message}, files: files}} ->
+                %{
+                  message: message,
+                  files: files |> Enum.map(&Map.take(&1, [:filename, :patch]))
+                }
+
+              _ ->
+                nil
+            end
+          end)
+          |> Enum.reject(&is_nil/1)
+
+        {:ok, commits}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp write_comment(pr, commits) do
+    user_content = """
+    Here's the information about the pull request:
+
+    <pr_title>
+    #{pr.title}
+    </pr_title>
+
+    <pr_body>
+    #{pr.body}
+    </pr_body>
+    """
+
+    user_content =
+      commits
+      |> Enum.reduce(user_content, fn %{message: message, files: files}, acc ->
+        files_rendered =
+          files
+          |> Enum.map(fn %{filename: filename, patch: patch} ->
+            """
+            <commit_file>
+            <commit_file_name>
+            #{filename}
+            </commit_file_name>
+
+            <commit_file_patch>
+            #{patch}
+            </commit_file_patch>
+            </commit_file>
+            """
+            |> String.trim()
+          end)
+          |> Enum.join("\n")
+
+        commit_rendered =
+          """
+          <commit>
+          <commit_message>
+          #{message}
+          </commit_message>
+
+          <commit_files>
+          #{files_rendered}
+          </commit_files>
+          </commit>
+          """
+          |> String.trim()
+
+        acc <> "\n\n" <> commit_rendered
+      end)
+
+    result =
+      Fastrepl.AI.chat(%{
+        model: "gpt-4o",
+        stream: false,
+        temperature: 0.2,
+        messages: [
+          %{
+            role: "system",
+            content: """
+            You are a senior software engineer with extensive experience in leading open source projects.
+            The user will provide you a information about the pull request. You should summarize the pull request and its changes.
+
+            Your response should be valid, rich markdown that Github supports. Use backticks(``) for variable, filenames, package name, etc.
+            Only use `### Description` and `#### Changes` sections. ``### Description` should be one-liner describing "What" the PR is about.
+            ``#### Changes` should be a list of descriptions of each main change. Each item in list should be very concise and short, and should not have child list.
+
+            At the high level, it should look like this:
+
+            ### Description
+            This PR ~
+
+            #### Changes
+            - Updated ~
+            """
+          },
+          %{
+            role: "user",
+            content: user_content
+          }
+        ]
+      })
+
+    case result do
+      {:ok, content} ->
+        comment =
+          """
+          <details by="fastrepl">
+          <summary>For reviewers</summary>
+
+          #{content}
+          ---
+          _Generated by [Fastrepl](https://github.com/fastrepl/fastrepl)_
+          </details>
+          """
+          |> String.trim()
+
+        {:ok, comment}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+end

--- a/lib/fastrepl/pr/summary.ex
+++ b/lib/fastrepl/pr/summary.ex
@@ -152,16 +152,24 @@ defmodule Fastrepl.PullRequest.Summary do
             The user will provide you a information about the pull request. You should summarize the pull request and its changes.
 
             Your response should be valid, rich markdown that Github supports. Use backticks(``) for variable, filenames, package name, etc.
-            Only use `### Description` and `#### Changes` sections. ``### Description` should be one-liner describing "What" the PR is about.
-            ``#### Changes` should be a list of descriptions of each main change. Each item in list should be very concise and short, and should not have child list.
+
+            Only use `### Description`, `#### Major Changes`, and OPTIONALLY `#### Minor Changes` sections.
+            ``### Description` should be one-liner describing "What" the PR is about.
+            `#### Major Changes` should be a list of descriptions of each main change. Each item in list should be very concise and short, and should not have child list.
+
+            Ideally, there should be no `#### Minor Changes` section. But sometimes, PR contains some changes that are not related to the main purpose of the PR.
+            If that change is not small enough to ignore, place it at `#### Major Changes` section.
 
             At the high level, it should look like this:
 
             ### Description
             This PR ~
 
-            #### Changes
-            - Updated ~
+            #### Major Changes
+            - Added ~
+
+            #### Minor Changes
+            - Modified ~
             """
           },
           %{

--- a/lib/fastrepl_web/controllers/github_webhook.ex
+++ b/lib/fastrepl_web/controllers/github_webhook.ex
@@ -34,6 +34,9 @@ defmodule FastreplWeb.GithubWebhookHandler do
 
       "deleted" ->
         Github.delete_app_by_installation_id(installation_id)
+
+      _ ->
+        :ok
     end
   end
 


### PR DESCRIPTION
<details by="fastrepl">
<summary>For reviewers</summary>

### Description
This PR adds support for summarizing pull requests using an Oban worker and updates various configurations and handlers.

#### Major Changes
- Added support for summarizing pull requests using Oban worker in `Fastrepl.PullRequest.Summary`.
- Updated `config.exs` for Oban configuration.
- Updated GitHub webhook handler to handle `pull_request` events.
- Implemented `understand_pr` function to analyze PR content and commits.

#### Minor Changes
- Experimental line number tracking in `CodeDiff.svelte`.
- Added fallback in installation webhook handler.
- Updated prompt in `Fastrepl.PullRequest.Summary`.
---
_Generated by [Fastrepl](https://github.com/fastrepl/fastrepl)_
</details>